### PR TITLE
Use Hypercore with generic parameters removed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tracing = "0.1"
 pretty-hash = "0.4"
 futures-timer = "3"
 futures-lite = "1"
-hypercore = { version = "0.12", default-features = false }
+hypercore = { version = "0.13.0",  default-features = false }
 sha2 = "0.10"
 curve25519-dalek = "4"
 crypto_secretstream = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,6 @@ async-std = { version = "1.12.0", features = ["attributes", "unstable"] }
 async-compat = "0.2.1"
 tokio = { version = "1.27.0", features = ["macros", "net", "process", "rt", "rt-multi-thread", "sync", "time"] }
 env_logger = "0.7.1"
-random-access-storage = "5.0.0"
-random-access-disk = { version = "3.0.0", default-features = false }
-random-access-memory = "3.0.0"
 anyhow = "1.0.28"
 instant = "0.1"
 criterion = { version = "0.4", features = ["async_std"] }
@@ -67,8 +64,8 @@ wasm-bindgen = [
 ]
 sparse = ["hypercore/sparse"]
 cache = ["hypercore/cache"]
-tokio = ["hypercore/tokio", "random-access-disk/tokio"]
-async-std = ["hypercore/async-std", "random-access-disk/async-std"]
+tokio = ["hypercore/tokio"]
+async-std = ["hypercore/async-std"]
 # Used only in interoperability tests under tests/js-interop which use the javascript version of hypercore
 # to verify that this crate works. To run them, use:
 # cargo test --features js_interop_tests


### PR DESCRIPTION
Corresponding `Hypercore` pull request is [here](https://github.com/datrs/hypercore/pull/139). 

One nice thing is that this removes the `random-access-*` dependencies.